### PR TITLE
Added team coloring based on allegiance

### DIFF
--- a/DS3ConnectionInfo/DS3ConnectionInfo.csproj
+++ b/DS3ConnectionInfo/DS3ConnectionInfo.csproj
@@ -111,6 +111,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Team.cs" />
     <Compile Include="DS3Interop.cs" />
     <Compile Include="ETWPingMonitor.cs" />
     <Compile Include="FormatUtils.cs" />

--- a/DS3ConnectionInfo/MainWindow.xaml
+++ b/DS3ConnectionInfo/MainWindow.xaml
@@ -54,8 +54,14 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Slot" IsReadOnly="True" Binding="{Binding CharSlot}" SortDirection="Ascending" ElementStyle="{StaticResource textCenter}"></DataGridTextColumn>
                         <DataGridTextColumn Header="Char. Name" IsReadOnly="True" Binding="{Binding CharName}"></DataGridTextColumn>
-                        <DataGridTextColumn Header="Team" IsReadOnly="True" Binding="{Binding TeamName}"></DataGridTextColumn>
-                        <DataGridTextColumn Header="Steam Name" IsReadOnly="True" Binding="{Binding SteamName}">
+						<DataGridTextColumn Header="Team" IsReadOnly="True" Binding="{Binding TeamName}">
+							<DataGridTextColumn.ElementStyle>
+								<Style TargetType="{x:Type TextBlock}">
+									<Setter Property="Foreground" Value="{Binding TeamColor}"></Setter>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+						<DataGridTextColumn Header="Steam Name" IsReadOnly="True" Binding="{Binding SteamName}">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="{x:Type TextBlock}">
                                     <Setter Property="Foreground" Value="{Binding SteamNameColor}"></Setter>

--- a/DS3ConnectionInfo/MainWindow.xaml.cs
+++ b/DS3ConnectionInfo/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ namespace DS3ConnectionInfo
             Player.UpdateInGameInfo();
             playerData.Clear();
 
-            foreach (Player p in Player.ActivePlayers().OrderBy(p => p.CharSlot))
+            foreach (Player p in Player.ActivePlayers().OrderBy(p => p.TeamAlliegance))
                 playerData.Add(p);
 
             // Update session info column sizes

--- a/DS3ConnectionInfo/OverlayWindow.xaml
+++ b/DS3ConnectionInfo/OverlayWindow.xaml
@@ -48,7 +48,7 @@
                 <DataGridTemplateColumn Header="Team Name">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <local:OverlayTextBlock Text="{Binding TeamName}" Style="{StaticResource defaultStyle}" />
+							<local:OverlayTextBlock Text="{Binding TeamName}" Fill="{Binding TeamColor}" Style="{StaticResource defaultStyle}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/DS3ConnectionInfo/OverlayWindow.xaml
+++ b/DS3ConnectionInfo/OverlayWindow.xaml
@@ -48,7 +48,7 @@
                 <DataGridTemplateColumn Header="Team Name">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-							<local:OverlayTextBlock Text="{Binding TeamName}" Fill="{Binding TeamColor}" Style="{StaticResource defaultStyle}" />
+                            <local:OverlayTextBlock Text="{Binding TeamName}" Fill="{Binding TeamColor}" Style="{StaticResource defaultStyle}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/DS3ConnectionInfo/Player.cs
+++ b/DS3ConnectionInfo/Player.cs
@@ -16,32 +16,6 @@ namespace DS3ConnectionInfo
     {
         private const long baseB = 0x4768E78;
 
-        public static readonly Dictionary<int, string> TeamNames = new Dictionary<int, string>()
-        {
-            {1, "Host"},
-            {2, "Phantom"},
-            {3, "Black Phantom"},
-            {4, "Hollow"},
-            {6, "Enemy"},
-            {7, "Boss (giants, big lizard)"},
-            {8, "Friend"},
-            {9, "AngryFriend"},
-            {10, "DecoyEnemy"},
-            {11, "BloodChild"},
-            {12, "BattleFriend"},
-            {13, "Dragon"},
-            {16, "Dark Spirit"},
-            {17, "Watchdog of Farron"},
-            {18, "Aldrich Faithful"},
-            {24, "Darkwraiths"},
-            {26, "NPC"},
-            {27, "Hostile NPC"},
-            {29, "Arena"},
-            {31, "Mad Phantom"},
-            {32, "Mad Spirit"},
-            {33, "Giant crabs, Dragons from Lothric castle"},
-            {0, "None"}
-        };
 
         private static Dictionary<CSteamID, Player> activePlayers = new Dictionary<CSteamID, Player>();
 
@@ -55,7 +29,8 @@ namespace DS3ConnectionInfo
         public string CharName { get; private set; }
         public int TeamId { get; private set; }
 
-        public string TeamName => TeamNames.ContainsKey(TeamId) ? TeamNames[TeamId] : "";
+        public string TeamName => Team.GetTeamFromId(TeamId).Name;
+        public TeamAllegiance TeamAlliegance => Team.GetTeamFromId(TeamId).Allegiance;
         public ulong SteamId64 => SteamID.m_SteamID;
         public double Ping => ETWPingMonitor.GetPing(NetId);
         public double AveragePing => ETWPingMonitor.GetAveragePing(NetId);
@@ -64,6 +39,7 @@ namespace DS3ConnectionInfo
 
         public SolidColorBrush SteamNameColor => new SolidColorBrush((Color)ColorConverter.ConvertFromString(
             (CharSlot == "") ? Settings.Default.ConnectingColor : "#FFFFFFFF"));
+        public SolidColorBrush TeamColor => new SolidColorBrush((Color)ColorConverter.ConvertFromString(Team.GetTeamFromId(TeamId).Color));
 
         public string OverlayName => GetOverlayName();
         private string GetOverlayName()
@@ -72,7 +48,7 @@ namespace DS3ConnectionInfo
             string fmt = (CharSlot == "") ? Settings.Default.NameFormatConnecting : Settings.Default.NameFormat;
             return FormatUtils.NamedFormat(fmt, keyNames, SteamName, CharName);
         }
-
+        
         public string PingColor
         {
             get
@@ -92,7 +68,7 @@ namespace DS3ConnectionInfo
                 }
             }
         }
-
+        
         private Player(CSteamID steamID)
         {
             SteamID = steamID;

--- a/DS3ConnectionInfo/Player.cs
+++ b/DS3ConnectionInfo/Player.cs
@@ -48,7 +48,7 @@ namespace DS3ConnectionInfo
             string fmt = (CharSlot == "") ? Settings.Default.NameFormatConnecting : Settings.Default.NameFormat;
             return FormatUtils.NamedFormat(fmt, keyNames, SteamName, CharName);
         }
-        
+
         public string PingColor
         {
             get
@@ -68,7 +68,7 @@ namespace DS3ConnectionInfo
                 }
             }
         }
-        
+
         private Player(CSteamID steamID)
         {
             SteamID = steamID;

--- a/DS3ConnectionInfo/Team.cs
+++ b/DS3ConnectionInfo/Team.cs
@@ -9,8 +9,8 @@ namespace DS3ConnectionInfo
     /// <summary>
     /// "Loyalty" refers to who that individual is not allowed to hurt, "Mission" refers to who the individual is incentivized to hurt
     /// </summary>
-	public enum TeamAllegiance
-	{
+    public enum TeamAllegiance
+    {
         Host,       /// Loyal to host, mission to keep host alive until and through critical battle
         Protector,  /// Loyal to host, mission to keep host alive until invaders are dispatched
         Mad,        /// Loyal to none, mission to kill the host or any phantom
@@ -18,14 +18,14 @@ namespace DS3ConnectionInfo
         Defender,   /// Loyal to each other, mission to kill host
         Enemy,      /// Loyal to each other, mission to kill host and those loyal, or any invader if Seed of a Giant used
         Unknown     /// Loyalty and mission unidentified, complicated, or depends on host actions
-	}
-
+    }
+    
     public class Team
     {
         public string Name { get; private set; }
         public TeamAllegiance Allegiance { get; private set; }
         public string Color => colors[Allegiance];
-
+        
         private static readonly Dictionary<int, Team> teams = new Dictionary<int, Team>()
         {
             {1,  new Team("Host",                                       TeamAllegiance.Host) },
@@ -52,7 +52,7 @@ namespace DS3ConnectionInfo
             {33, new Team("Giant crabs, Dragons from Lothric castle",   TeamAllegiance.Enemy) },
             {0,  new Team("None",                                       TeamAllegiance.Unknown) }
         };
-
+        
         private static readonly Dictionary<TeamAllegiance, string> colors = new Dictionary<TeamAllegiance, string>()
         {
             { TeamAllegiance.Host,      "#FFFFFFFF" },
@@ -63,16 +63,16 @@ namespace DS3ConnectionInfo
             { TeamAllegiance.Enemy,     "#FF006400" },
             { TeamAllegiance.Unknown,   "#FFFFA500" },
         };
-
+        
         private Team(string name, TeamAllegiance allegiance)
         {
             Name = name;
             Allegiance = allegiance;
-		}
-
+        }
+        
         public static Team GetTeamFromId(int id)
         {
             return teams.ContainsKey(id) ? teams[id] : teams[0];
-		}
-	}
+        }
+    }
 }

--- a/DS3ConnectionInfo/Team.cs
+++ b/DS3ConnectionInfo/Team.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DS3ConnectionInfo
+{
+    /// <summary>
+    /// "Loyalty" refers to who that individual is not allowed to hurt, "Mission" refers to who the individual is incentivized to hurt
+    /// </summary>
+	public enum TeamAllegiance
+	{
+		Host,       /// Loyal to host, mission to keep host alive until and through critical battle
+        Protector,  /// Loyal to host, mission to keep host alive until invaders are dispatched
+        Mad,        /// Loyal to none, mission to kill the host or any phantom
+        Invader,    /// Loyal to none, mission to kill the host
+        Defender,   /// Loyal to each other, mission to kill host
+        Enemy,      /// Loyal to each other, mission to kill host and those loyal, or any invader if Seed of a Giant used
+        Unknown     /// Loyalty and mission unidentified, complicated, or depends on host actions
+	}
+
+    public class Team
+    {
+        public string Name { get; private set; }
+        public TeamAllegiance Allegiance { get; private set; }
+        public string Color => colors[Allegiance];
+
+        private static readonly Dictionary<int, Team> teams = new Dictionary<int, Team>()
+        {
+            {1,  new Team("Host",                                       TeamAllegiance.Host) },
+            {2,  new Team("Phantom",                                    TeamAllegiance.Host) },
+            {3,  new Team("Black Phantom",                              TeamAllegiance.Invader) },
+            {4,  new Team("Hollow",                                     TeamAllegiance.Host) },
+            {6,  new Team("Enemy",                                      TeamAllegiance.Enemy) },
+            {7,  new Team("Boss (giants, big lizard)",                  TeamAllegiance.Enemy) },
+            {8,  new Team("Friend",                                     TeamAllegiance.Host) },
+            {9,  new Team("AngryFriend",                                TeamAllegiance.Enemy) },
+            {10, new Team("DecoyEnemy",                                 TeamAllegiance.Enemy) },
+            {11, new Team("BloodChild",                                 TeamAllegiance.Unknown) },
+            {12, new Team("BattleFriend",                               TeamAllegiance.Unknown) },
+            {13, new Team("Dragon",                                     TeamAllegiance.Unknown) },
+            {16, new Team("Dark Spirit",                                TeamAllegiance.Invader) },
+            {17, new Team("Watchdog of Farron",                         TeamAllegiance.Defender) },
+            {18, new Team("Aldrich Faithful",                           TeamAllegiance.Defender) },
+            {24, new Team("Darkwraiths",                                TeamAllegiance.Unknown) },
+            {26, new Team("NPC",                                        TeamAllegiance.Unknown) },
+            {27, new Team("Hostile NPC",                                TeamAllegiance.Unknown) },
+            {29, new Team("Arena",                                      TeamAllegiance.Unknown) },
+            {31, new Team("Mad Phantom",                                TeamAllegiance.Mad) },
+            {32, new Team("Mad Spirit",                                 TeamAllegiance.Mad) },
+            {33, new Team("Giant crabs, Dragons from Lothric castle",   TeamAllegiance.Enemy) },
+            {0,  new Team("None",                                       TeamAllegiance.Unknown) }
+        };
+
+        private static readonly Dictionary<TeamAllegiance, string> colors = new Dictionary<TeamAllegiance, string>()
+        {
+            { TeamAllegiance.Host,      "#FFFFFFFF" },
+            { TeamAllegiance.Protector, "#FF0000FF" },
+            { TeamAllegiance.Mad,       "#FFC71585" },
+            { TeamAllegiance.Invader,   "#FFFF0000" },
+            { TeamAllegiance.Defender,  "#FF7B68EE" },
+            { TeamAllegiance.Enemy,     "#FF006400" },
+            { TeamAllegiance.Unknown,   "#FFFFA500" },
+        };
+
+        private Team(string name, TeamAllegiance allegiance)
+        {
+            Name = name;
+            Allegiance = allegiance;
+		}
+
+        public static Team GetTeamFromId(int id)
+        {
+            return teams.ContainsKey(id) ? teams[id] : teams[0];
+		}
+	}
+}

--- a/DS3ConnectionInfo/Team.cs
+++ b/DS3ConnectionInfo/Team.cs
@@ -11,7 +11,7 @@ namespace DS3ConnectionInfo
     /// </summary>
 	public enum TeamAllegiance
 	{
-		Host,       /// Loyal to host, mission to keep host alive until and through critical battle
+        Host,       /// Loyal to host, mission to keep host alive until and through critical battle
         Protector,  /// Loyal to host, mission to keep host alive until invaders are dispatched
         Mad,        /// Loyal to none, mission to kill the host or any phantom
         Invader,    /// Loyal to none, mission to kill the host


### PR DESCRIPTION
When invading or being invaded, it's useful to see at a glance what the current battle situation is, especially during a battle with many people. Especially useful is seeing how many invaders or how many phantoms are currently present.

Before, this meant reading the list of phantoms/invaders, and tallying up the count in your head. It was made more difficult by the fact that players were sorted by slot number, which is not at useful, and makes it harder to find a certain player, like the name of the host. Now, with the teams color coded and sorted based on allegiance or malice to the host, it's easy to quickly glance at the list and see what the current battle situation is.

Currently does not include settings to modify team colors, because I am unfamiliar with how to do that.

Team allegiances are sorted and colored based on what other players/enemies they're allowed to hurt, and what their mission is.